### PR TITLE
Allow for multiple manifest dirs

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -108,32 +108,26 @@ type Commands struct {
 func Manifests() (m []*Manifest, err error) {
 	m = make([]*Manifest, 0)
 
-	err = filepath.Walk(pkgDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if info.Name() == "manifest.toml" {
-			man, err := readManifest(path)
+	for _, dir := range filepath.SplitList(pkgDir) {
+		err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
 
-			m = append(m, &man)
-		}
+			if info.Name() == ManifestFilename {
+				man, err := readManifest(path)
+				if err != nil {
+					return err
+				}
 
-		return nil
-	})
+				m = append(m, &man)
+			}
+
+			return nil
+		})
+	}
 
 	return
-}
-
-// ReadManifest takes a package and version, loads the necessary manifest file,
-// Parses, and returns a Manifest for processing
-func ReadManifest(pkg, ver string) (m Manifest, err error) {
-	filename := manifestPath(pkg, ver)
-
-	return readManifest(filename)
 }
 
 func readManifest(filename string) (m Manifest, err error) {

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -1,16 +1,12 @@
 package main
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 )
 
 func TestReadManifest(t *testing.T) {
-	oldPkgDir := pkgDir
-	defer func() {
-		pkgDir = oldPkgDir
-	}()
-
 	pkgDir = "testdata/manifests"
 
 	for _, test := range []struct {
@@ -26,7 +22,7 @@ func TestReadManifest(t *testing.T) {
 		{"invalid dep", "invalid", "0.1.1", Manifest{ID: "invalid 0.1.1", Provides: "invalid", VersionStr: "0.1.1", Profiles: map[string]Profile{"default": Profile{Deps: []Dep{Dep{"bash", "xxx"}}}}}, true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			received, err := ReadManifest(test.pkg, test.ver)
+			received, err := readManifest(filepath.Join(pkgDir, test.pkg, test.ver, ManifestFilename))
 
 			if err == nil && test.expectError {
 				t.Error("expected error, received none")

--- a/os.go
+++ b/os.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	pkgDir = getEnv("PKGROOT", "/etc/vinyl/pkg")
+	pkgDir = getEnv("MANIFESTPATH", "/etc/vinyl/pkg")
 )
 
 func getEnv(key, def string) string {
@@ -26,10 +26,6 @@ func getEnv(key, def string) string {
 	}
 
 	return v
-}
-
-func manifestPath(pkg, ver string) string {
-	return filepath.Join(pkgDir, pkg, ver, ManifestFilename)
 }
 
 // checksum takes a filename, opens it, and generates a Blake3 sum from it


### PR DESCRIPTION
Allow for multiple directories to be used as sources for manifests, thus allowing for third party repositories/ development of packages within `vin`.

This PR introduces the environment variable `MANIFESTPATH`. This works the same as `PATH` in Linux; multiple directories, delimited with a colon (`:`). Manifests found later directories will (I assume) override earlier ones.