### PR TITLE
Allow meta packages

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -81,6 +81,7 @@ type Manifest struct {
 	Checksum   string
 	Licence    string
 	Tarball    string
+	Meta       bool
 
 	Profiles map[string]Profile
 	Commands Commands

--- a/server.go
+++ b/server.go
@@ -105,6 +105,12 @@ func (s Server) Install(is *server.InstallSpec, vs server.Vin_InstallServer) (er
 			continue
 		}
 
+		if task.Meta {
+			output <- fmt.Sprintf("%s is a meta-package, skipping", task.ID)
+
+			continue
+		}
+
 		err = task.Prepare(output)
 		if err != nil {
 			return

--- a/server_test.go
+++ b/server_test.go
@@ -58,6 +58,7 @@ func TestServer_Install(t *testing.T) {
 		{"valid package, 404 archive", "standalone", "0.1.3", true},
 		{"erroring commands", "standalone", "0.1.0", true},
 		{"missing package", "", "", true},
+		{"meta package", "metaz", "", false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			// create an empty statedb

--- a/testdata/manifests/valid-manifests/metaz/0.1.0/manifest.toml
+++ b/testdata/manifests/valid-manifests/metaz/0.1.0/manifest.toml
@@ -1,0 +1,7 @@
+provides = "metaz"
+version = "0.1.0"
+meta = true
+
+[profiles]
+[profiles.default]
+deps = []


### PR DESCRIPTION
A meta package is one which provides no actual package _per se_, but rather a collection of other packages which are stored as dependencies. In this sense, then, a meta package combines many packages in a single installation target.