### PR TITLE
Generate sample config file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,7 +27,7 @@ jobs:
       run: go build -v
 
     - name: Test
-      run: go test -v -covermode=count -coverprofile=coverage.out
+      run: go test -v -covermode=count -coverprofile=coverage.out ./...
 
     - name: Convert coverage to lcov
       uses: jandelgado/gcov2lcov-action@v1.0.8
@@ -48,7 +48,7 @@ jobs:
         fetch-depth: 0
 
     - name: Test
-      run: go test -covermode=count -coverprofile=coverage.out
+      run: go test -covermode=count -coverprofile=coverage.out ./...
 
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master

--- a/client/cmd/advise.go
+++ b/client/cmd/advise.go
@@ -1,0 +1,67 @@
+/*
+Copyright © 2021 James Condron <james@zero-internet.org.uk>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+package cmd
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/vinyl-linux/vin/config"
+)
+
+// adviseCmd represents the advise command
+var adviseCmd = &cobra.Command{
+	Use:   "advise",
+	Short: "generate a vin config.toml for this machine",
+	Long:  "generate a vin config.toml for this machine",
+	Run: func(cmd *cobra.Command, args []string) {
+		c := config.Config{}
+
+		c.ConfigureFlags = "--prefix=/ --enable-openssl"
+		c.MakeOpts = fmt.Sprintf("-j%d", int(math.Max(float64(runtime.NumCPU()-1), 1.0)))
+
+		c.CFlags = "-D_FORTIFY_SOURCE=2 -fasynchronous-unwind-tables -fexceptions -fpie -Wl,-pie -fpic -shared -fstack-clash-protection -fstack-protector-strong -mcet -fcf-protection -O2 -pipe -Wall -Werror=format-security -Werror=implicit-function-declaration -Wl,-z,defs"
+		c.CXXFlags = c.CFlags
+
+		fmt.Fprintln(cmd.OutOrStdout(), "# vin config file")
+		fmt.Fprintln(cmd.OutOrStdout(), "#")
+		fmt.Fprintf(cmd.OutOrStdout(), "# generated at %s\n", time.Now())
+		fmt.Fprintln(cmd.OutOrStdout())
+		fmt.Fprint(cmd.OutOrStdout(), c.String())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(adviseCmd)
+}

--- a/client/cmd/advise.go
+++ b/client/cmd/advise.go
@@ -48,7 +48,7 @@ var adviseCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		c := config.Config{}
 
-		c.ConfigureFlags = "--prefix=/ --enable-openssl"
+		c.ConfigureFlags = "--prefix=/ --enable-openssl --disable-multilib"
 		c.MakeOpts = fmt.Sprintf("-j%d", int(math.Max(float64(runtime.NumCPU()-1), 1.0)))
 
 		c.CFlags = "-D_FORTIFY_SOURCE=2 -fasynchronous-unwind-tables -fexceptions -fpie -Wl,-pie -fpic -shared -fstack-clash-protection -fstack-protector-strong -mcet -fcf-protection -O2 -pipe -Wall -Werror=format-security -Werror=implicit-function-declaration -Wl,-z,defs"
@@ -57,6 +57,9 @@ var adviseCmd = &cobra.Command{
 		fmt.Fprintln(cmd.OutOrStdout(), "# vin config file")
 		fmt.Fprintln(cmd.OutOrStdout(), "#")
 		fmt.Fprintf(cmd.OutOrStdout(), "# generated at %s\n", time.Now())
+		fmt.Fprintln(cmd.OutOrStdout(), "# note: this config will only build 64bit versions of stuff. Remove --disable-multilib")
+		fmt.Fprintln(cmd.OutOrStdout(), "# from configure_flags if this is not what you expect to happen.")
+
 		fmt.Fprintln(cmd.OutOrStdout())
 		fmt.Fprint(cmd.OutOrStdout(), c.String())
 	},

--- a/client/cmd/root_test.go
+++ b/client/cmd/root_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	defaultExpect  = "vin provides package management stuff for vinyl linux\n\nIt offers:\n  * Speed and extensibility- no mucking around with byzantine package manager configs\n  * Modern tooling- sha and md5 are slow and unwieldly. We've moved on. PGP signing package manifests. Why? Sod it, let git handle it\n  * Low barrier to entry for contributing- why are we mucking about with granting access to servers/ mailing lists to make changes? Github/ gitlab/ gitea/ all of these solve these issues better. Slap a reasonably permissive CLA onto a repo somewhere, and let people do what they do.\n\nUsage:\n  vin [command]\n\nAvailable Commands:\n  help        Help about any command\n  install     install packages\n  reload      trigger a reload of manifests\n\nFlags:\n      --config string   config file (default is $HOME/.vin.yaml)\n  -h, --help            help for vin\n      --sock string     path to the vin socket file (default \"unix:///var/run/vin.sock\")\n\nUse \"vin [command] --help\" for more information about a command.\n"
+	defaultExpect  = "vin provides package management stuff for vinyl linux\n\nIt offers:\n  * Speed and extensibility- no mucking around with byzantine package manager configs\n  * Modern tooling- sha and md5 are slow and unwieldly. We've moved on. PGP signing package manifests. Why? Sod it, let git handle it\n  * Low barrier to entry for contributing- why are we mucking about with granting access to servers/ mailing lists to make changes? Github/ gitlab/ gitea/ all of these solve these issues better. Slap a reasonably permissive CLA onto a repo somewhere, and let people do what they do.\n\nUsage:\n  vin [command]\n\nAvailable Commands:\n  advise      generate a vin config.toml for this machine\n  help        Help about any command\n  install     install packages\n  reload      trigger a reload of manifests\n\nFlags:\n      --config string   config file (default is $HOME/.vin.yaml)\n  -h, --help            help for vin\n      --sock string     path to the vin socket file (default \"unix:///var/run/vin.sock\")\n\nUse \"vin [command] --help\" for more information about a command.\n"
 	defaultInstall = "Usage:\n  vin install [package name] [flags]\n\nFlags:\n  -f, --force            Force installation, even when targets are marked as installed\n  -h, --help             help for install\n  -v, --version string   Version constraint to install. This command allows strict versions, such as \"1.2.3\", or loose versions such as \">=1.20, <1.3.5\" (default \"latest\")\n\nGlobal Flags:\n      --config string   config file (default is $HOME/.vin.yaml)\n      --sock string     path to the vin socket file (default \"unix:///var/run/vin.sock\")\n"
 	defaultReload  = ""
 )
@@ -75,5 +75,32 @@ func TestRootCmd(t *testing.T) {
 				t.Errorf("expected\n\t%q\nreceived\n\t%q", test.expect, got)
 			}
 		})
+	}
+}
+
+func TestRootCmd_Advise(t *testing.T) {
+	// Separate this from the above; we don't care so much _what_ the output
+	// is, just that there is some and nothing crashes
+
+	defer func() {
+		err := recover()
+		if err != nil {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+	}()
+
+	rootCmd.SetArgs([]string{"advise"})
+
+	b := &bytes.Buffer{}
+	rootCmd.SetOut(b)
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+
+	got := b.String()
+	if got == "" {
+		t.Fatalf("expected _some_ output")
 	}
 }

--- a/config.go
+++ b/config.go
@@ -1,42 +1,14 @@
 package main
 
 import (
-	"io/ioutil"
 	"strings"
 	"text/template"
 
-	"github.com/pelletier/go-toml"
+	"github.com/vinyl-linux/vin/config"
 )
 
-// Config holds all of the configuration that vin needs,
-// including things like make/ confdigure opts, and so on
-//
-// This struct can be passed into builds to allow for templating
-// build opts
-type Config struct {
-	// Flags passed to './configure'. These options are available to
-	// commands, in order to set flags during compilation.
-	//
-	// Note that --prefix is always set by vin
-	ConfigureFlags string
-
-	// MakeOpts are passed to make
-	MakeOpts string
-}
-
-func LoadConfig() (c Config, err error) {
-	d, err := ioutil.ReadFile(configFile)
-	if err != nil {
-		return
-	}
-
-	err = toml.Unmarshal(d, &c)
-
-	return
-}
-
 type InstallationValues struct {
-	Config
+	config.Config
 	*Manifest
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -16,15 +16,15 @@ type Config struct {
 	// commands, in order to set flags during compilation.
 	//
 	// Note that --prefix is always set by vin
-	ConfigureFlags string
+	ConfigureFlags string `toml:"configure_flags"`
 
 	// MakeOpts are passed to make
-	MakeOpts string
+	MakeOpts string `toml:"MAKEOPTS"`
 
 	// CFlags and CXXFlags are inserted into the environment when
 	// running build commands
-	CFlags   string
-	CXXFlags string
+	CFlags   string `toml:"CFLAGS"`
+	CXXFlags string `toml:CXXFLAGS"`
 }
 
 func Load(configFile string) (c Config, err error) {
@@ -36,4 +36,12 @@ func Load(configFile string) (c Config, err error) {
 	err = toml.Unmarshal(d, &c)
 
 	return
+}
+
+func (c Config) String() string {
+	// swallow errors, they're both massively unlikely, and
+	// not used anywhere where error handling is necessary
+	b, _ := toml.Marshal(c)
+
+	return string(b)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	// CFlags and CXXFlags are inserted into the environment when
 	// running build commands
 	CFlags   string `toml:"CFLAGS"`
-	CXXFlags string `toml:CXXFLAGS"`
+	CXXFlags string `toml:"CXXFLAGS"`
 }
 
 func Load(configFile string) (c Config, err error) {

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"io/ioutil"
+
+	"github.com/pelletier/go-toml"
+)
+
+// Config holds all of the configuration that vin needs,
+// including things like make/ confdigure opts, and so on
+//
+// This struct can be passed into builds to allow for templating
+// build opts
+type Config struct {
+	// Flags passed to './configure'. These options are available to
+	// commands, in order to set flags during compilation.
+	//
+	// Note that --prefix is always set by vin
+	ConfigureFlags string
+
+	// MakeOpts are passed to make
+	MakeOpts string
+
+	// CFlags and CXXFlags are inserted into the environment when
+	// running build commands
+	CFlags   string
+	CXXFlags string
+}
+
+func Load(configFile string) (c Config, err error) {
+	d, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return
+	}
+
+	err = toml.Unmarshal(d, &c)
+
+	return
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,9 +5,36 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	configFile = "this-file-should-not-exist"
-	_, err := LoadConfig()
-	if err == nil {
-		t.Errorf("expected error, received none")
+	for _, test := range []struct {
+		path        string
+		expectError bool
+	}{
+		{"/this/file/does/not.exist", true},
+		{"../testdata/test-config.toml", false},
+	} {
+		t.Run(test.path, func(t *testing.T) {
+			_, err := Load(test.path)
+			if err == nil && test.expectError {
+				t.Error("expected error, received none")
+			} else if err != nil && !test.expectError {
+				t.Errorf("unexpected error: %+v", err)
+			}
+		})
+	}
+}
+
+func TestConfig_String(t *testing.T) {
+	defer func() {
+		err := recover()
+		if err != nil {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+	}()
+
+	c := Config{}.String()
+	expect := "CFLAGS = \"\"\nCXXFLAGS = \"\"\nMAKEOPTS = \"\"\nconfigure_flags = \"\"\n"
+
+	if expect != c {
+		t.Errorf("expected:\n%sreceived:\n%s", expect, c)
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	configFile = "this-file-should-not-exist"
+	_, err := LoadConfig()
+	if err == nil {
+		t.Errorf("expected error, received none")
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -2,20 +2,14 @@ package main
 
 import (
 	"testing"
-)
 
-func TestLoadConfig(t *testing.T) {
-	configFile = "this-file-should-not-exist"
-	_, err := LoadConfig()
-	if err == nil {
-		t.Errorf("expected error, received none")
-	}
-}
+	"github.com/vinyl-linux/vin/config"
+)
 
 func TestInstallationValues_Expand(t *testing.T) {
 	configFile = "testdata/test-config.toml"
 
-	c, err := LoadConfig()
+	c, err := config.Load(configFile)
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -42,7 +42,7 @@ func TestInstallationValues_Expand(t *testing.T) {
 			}
 
 			if test.expect != got {
-				t.Errorf("expected %q, received %q", test.expect, err)
+				t.Errorf("expected %q, received %q", test.expect, got)
 			}
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	"github.com/vinyl-linux/vin/config"
 	"github.com/vinyl-linux/vin/server"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -50,7 +51,7 @@ func Setup() *grpc.Server {
 	sugar.Info("starting")
 	sugar.Info("loading config")
 
-	c, err := LoadConfig()
+	c, err := config.Load(configFile)
 	if err != nil {
 		sugar.Panic(err)
 	}

--- a/manifest.go
+++ b/manifest.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/pelletier/go-toml"
+	"github.com/vinyl-linux/vin/config"
 )
 
 const (
@@ -226,7 +227,7 @@ func (c Commands) Patch(wd string, output chan string) (err error) {
 		patchCmd := fmt.Sprintf("patch -p1 -i %s", p)
 
 		output <- fmt.Sprintf("patch %d/%d", i+1, patches)
-		err = execute(wd, patchCmd, output)
+		err = execute(wd, patchCmd, output, config.Config{})
 		if err != nil {
 			return
 		}

--- a/os.go
+++ b/os.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/h2non/filetype"
+	"github.com/vinyl-linux/vin/config"
 	"github.com/zeebo/blake3"
 )
 
@@ -208,7 +209,7 @@ func decompressLoop(tr *tar.Reader, dest string) (err error) {
 	}
 }
 
-func execute(dir, command string, output chan string) (err error) {
+func execute(dir, command string, output chan string, c config.Config) (err error) {
 	cmdSlice := strings.Fields(command)
 
 	var args []string
@@ -224,6 +225,9 @@ func execute(dir, command string, output chan string) (err error) {
 
 	cmd := exec.CommandContext(context.Background(), cmdSlice[0], args...)
 	cmd.Dir = dir
+
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("CFLAGS=%s", c.CFlags), fmt.Sprintf("CXXFLAGS=%s", c.CXXFlags))
 
 	outputWriter := ChanWriter(output)
 	cmd.Stdout = outputWriter

--- a/os_test.go
+++ b/os_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/vinyl-linux/vin/config"
 )
 
 func TestUntar(t *testing.T) {
@@ -70,7 +72,7 @@ func TestExecute(t *testing.T) {
 				}
 			}()
 
-			err := execute(test.dir, test.command, output)
+			err := execute(test.dir, test.command, output, config.Config{})
 			close(output)
 			if err == nil && test.expectError {
 				t.Errorf("expected error")

--- a/server.go
+++ b/server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-version"
+	"github.com/vinyl-linux/vin/config"
 	"github.com/vinyl-linux/vin/server"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -20,13 +21,13 @@ type Server struct {
 	server.UnimplementedVinServer
 
 	sdb    StateDB
-	config Config
+	config config.Config
 	mdb    ManifestDB
 
 	operationLock *sync.Mutex
 }
 
-func NewServer(c Config, m ManifestDB, sdb StateDB) (s Server, err error) {
+func NewServer(c config.Config, m ManifestDB, sdb StateDB) (s Server, err error) {
 	return Server{
 		UnimplementedVinServer: server.UnimplementedVinServer{},
 		sdb:                    sdb,
@@ -130,7 +131,7 @@ func (s Server) Install(is *server.InstallSpec, vs server.Vin_InstallServer) (er
 				return
 			}
 
-			err = execute(workDir, cmd, output)
+			err = execute(workDir, cmd, output, s.config)
 			if err != nil {
 				return
 			}

--- a/server_test.go
+++ b/server_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/go-version"
+	"github.com/vinyl-linux/vin/config"
 	"github.com/vinyl-linux/vin/server"
 	"google.golang.org/grpc"
 )
@@ -27,7 +28,7 @@ func TestServer_Install(t *testing.T) {
 	cacheDir = "/tmp"
 	sockAddr = "/tmp/vin-test.sock"
 
-	c, err := LoadConfig()
+	c, err := config.Load(configFile)
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -91,7 +92,7 @@ func TestServer_Reload(t *testing.T) {
 	sockAddr = "/tmp/vin-test.sock"
 	stateDB = filepath.Join("/tmp", uuid.Must(uuid.NewV4()).String())
 
-	c, err := LoadConfig()
+	c, err := config.Load(configFile)
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}

--- a/testdata/test-config.toml
+++ b/testdata/test-config.toml
@@ -1,2 +1,2 @@
-configureFlags = "--enable-hello-world"
-makeOpts = "-j100"
+configure_flags = "--enable-hello-world"
+MAKEOPTS = "-j100"


### PR DESCRIPTION
The `vin.toml` file is under documented, and not massively intuitive.

This PR will allow us to generate a sample config file when a user calls `vin advise`

