### PR TITLE
Write vin.db on installation

### DIFF
--- a/server.go
+++ b/server.go
@@ -98,6 +98,9 @@ func (s Server) Install(is *server.InstallSpec, vs server.Vin_InstallServer) (er
 		cmd string
 	)
 
+	// Write world db to disk on return
+	defer s.sdb.Write()
+
 	// for each pkg
 	for _, task := range tasks {
 		if s.sdb.IsInstalled(task.ID) && !is.Force {
@@ -141,7 +144,6 @@ func (s Server) Install(is *server.InstallSpec, vs server.Vin_InstallServer) (er
 	}
 
 	s.sdb.AddWorld(is.Pkg, is.Version)
-	s.sdb.Write()
 
 	return
 }


### PR DESCRIPTION
Previously, an installation which fails at _any_ point in the process, whether in the first package or the -1th package, would bomb out and nothing would be written to disk until the next successful installation. This means that depenency packages end up installed but are never seen as installed.