### PR TITLE
Split multiline messages to allow for consistent prefixes

### DIFF
--- a/output.go
+++ b/output.go
@@ -12,6 +12,18 @@ var (
 	prefixColour = color.New(color.FgCyan, color.Bold)
 )
 
+func init() {
+	// Ensure colour escape codes are generated properly, in both
+	// gitlab actions _and_ when running `vind` under s6 - in both cases
+	// the `color` package doesn't create escape codes because we're not
+	// running as a real terminal.
+	//
+	// In the case of `vind` this is fine; we might not be a terminal, but
+	// the `vin` client is certainly running under one
+	color.NoColor = false
+
+}
+
 // Outputter handles writing strings to vin
 // clients by reading strings from a chan and writing
 // them, prefixed with an additional string, to a server.OutputSender
@@ -25,6 +37,7 @@ type Outputter struct {
 // NewOutputter takes an OutputSender and returns an Outputter
 // ready to be dispatched across
 func NewOutputter(o server.OutputSender) Outputter {
+
 	return Outputter{
 		C:      make(chan string),
 		Prefix: "",

--- a/output.go
+++ b/output.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/vinyl-linux/vin/server"
@@ -40,8 +41,10 @@ func (o *Outputter) Dispatch() {
 		// generate this for each message; the prefix can (and does) change often
 		prefix := prefixColour.Sprintf(o.Prefix)
 
-		o.o.Send(&server.Output{
-			Line: fmt.Sprintf("%s\t%s", prefix, msg),
-		})
+		for _, line := range strings.Split(msg, "\n") {
+			o.o.Send(&server.Output{
+				Line: fmt.Sprintf("%s\t%s", prefix, line),
+			})
+		}
 	}
 }

--- a/output_test.go
+++ b/output_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -32,12 +33,14 @@ func TestOutputter_Dispatch(t *testing.T) {
 	go o.Dispatch()
 
 	for _, test := range []struct {
-		prefix string
-		msg    string
-		expect string
+		prefix      string
+		msg         string
+		expectCount int
+		expect      string
 	}{
-		{"", "Hello, world!", "\x1b[36;1m\x1b[0m\tHello, world!"},
-		{"test", "Doing Tests!", "\x1b[36;1mtest\x1b[0m\tDoing Tests!"},
+		{"", "Hello, world!", 1, "\x1b[36;1m\x1b[0m\tHello, world!"},
+		{"test", "Doing Tests!", 1, "\x1b[36;1mtest\x1b[0m\tDoing Tests!"},
+		{"multiline", "Line 1\nAnd another!", 2, "\x1b[36;1mmultiline\x1b[0m\tLine 1\n\x1b[36;1mmultiline\x1b[0m\tAnd another!"},
 	} {
 		t.Run("", func(t *testing.T) {
 			vs.messages = []*server.Output{}
@@ -47,14 +50,20 @@ func TestOutputter_Dispatch(t *testing.T) {
 
 			time.Sleep(time.Millisecond * 200)
 
-			if len(vs.messages) != 1 {
-				t.Fatalf("vs.messages: expected %d, received %d", 1, len(vs.messages))
+			if len(vs.messages) != test.expectCount {
+				t.Fatalf("vs.messages: expected %d, received %d", test.expectCount, len(vs.messages))
 			}
 
-			if test.expect != vs.messages[0].Line {
-				t.Errorf("expected %q, recveived %q", test.expect, vs.messages[0].Line)
+			lines := []string{}
+			for _, m := range vs.messages {
+				lines = append(lines, m.Line)
 			}
 
+			got := strings.Join(lines, "\n")
+
+			if test.expect != got {
+				t.Errorf("expected %q, recveived %q", test.expect, got)
+			}
 		})
 	}
 }

--- a/output_test.go
+++ b/output_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/vinyl-linux/vin/server"
 )
 
@@ -23,10 +22,6 @@ func TestNewOutputter(t *testing.T) {
 func TestOutputter_Dispatch(t *testing.T) {
 	// This is a 'Test', rather than an 'Example' in order to test
 	// escape codes
-
-	// Ensure colour escape codes are still generated in github actions
-	// see: https://github.com/fatih/color/issues/132
-	color.NoColor = false
 
 	vs := &mockInstallServer{}
 	o := NewOutputter(vs)


### PR DESCRIPTION
Some output from `exec` is not written line by line, but in chunks. The `go` package is particularly susceptible to this.

Because of this, we must split all output by line in order to get the correct line prefix behaviour.