### PR TITLE
Remove leading/ trailing whitespace

### DIFF
--- a/output.go
+++ b/output.go
@@ -54,6 +54,8 @@ func (o *Outputter) Dispatch() {
 		// generate this for each message; the prefix can (and does) change often
 		prefix := prefixColour.Sprintf(o.Prefix)
 
+		msg = strings.TrimSpace(msg)
+
 		for _, line := range strings.Split(msg, "\n") {
 			o.o.Send(&server.Output{
 				Line: fmt.Sprintf("%s\t%s", prefix, line),

--- a/output_test.go
+++ b/output_test.go
@@ -36,6 +36,7 @@ func TestOutputter_Dispatch(t *testing.T) {
 		{"", "Hello, world!", 1, "\x1b[36;1m\x1b[0m\tHello, world!"},
 		{"test", "Doing Tests!", 1, "\x1b[36;1mtest\x1b[0m\tDoing Tests!"},
 		{"multiline", "Line 1\nAnd another!", 2, "\x1b[36;1mmultiline\x1b[0m\tLine 1\n\x1b[36;1mmultiline\x1b[0m\tAnd another!"},
+		{"trailing", "Trailing whitespace\n", 1, "\x1b[36;1mtrailing\x1b[0m\tTrailing whitespace"},
 	} {
 		t.Run("", func(t *testing.T) {
 			vs.messages = []*server.Output{}


### PR DESCRIPTION
Lines/ messages with trailing whitespace can cause empty lines to be set, which look awful on output