### PR TITLE
Ensure service starts, runs, upgrades properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ SERVICES := $(SRVDIR)/run      \
 	    $(SRVDIR)/conf     \
 	    $(SRVDIR)/log/run  \
 	    $(SRVDIR)/env/HOME \
-	    $(SRVDIR)/env/VIN_SOCKET_ADDR
+	    $(SRVDIR)/env/VIN_SOCKET_ADDR \
+	    $(SRVDIR)/env/FORCE_UNSAFE_CONFIGURE
 
 
 .PHONY: default

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,6 @@ vin: client/*.go client/**/*.go server/install.pb.go server/server.pb.go server/
 	(cd client && CGO_ENABLED=0 go build -o ../vin)
 
 installCmd     ?= install -m 0750 -o $(OWNER)
-confInstallCmd ?= install -m 0640 -o $(OWNER)
 
 .PHONY: install
 install: dirs $(BINARIES) $(CONFIGS) $(SERVICES)
@@ -60,8 +59,9 @@ install: dirs $(BINARIES) $(CONFIGS) $(SERVICES)
 $(BINDIR)/%: % $(BINDIR)
 	$(installCmd) $< $@
 
-$(ETCDIR)/%: $(ETCDIR)
-	$(confInstallCmd) /dev/null $@
+$(ETCDIR)/vin.toml: $(BINDIR)/vin $(ETCDIR)
+	[ -f $@ ] && mv $@ $@.bak
+	$< advise > $@
 
 $(SRVDIR)/%: service/% $(SRVDIR)
 	$(installCmd) $< $@

--- a/service/finish
+++ b/service/finish
@@ -1,3 +1,3 @@
 #!/bin/execlineb -P
 
-rm /var/run/vin.sock
+rm /run/vin.sock


### PR DESCRIPTION
Upgrades to vin were blatting away the vin config file, causing all kinds of bother.

Additionally, the env var `FORCE_UNSAFE_CONFIGURE=1` wasn't _actually_ being used.

The `finish` s6 script was failing, too. When a service was restarted, it'd fail gracefully, delete the correct socket file, then start properly. This is now fixed.