### PR TITLE
Simplify flags, selectively ignore CFLAGS

### DIFF
--- a/client/cmd/advise.go
+++ b/client/cmd/advise.go
@@ -40,6 +40,8 @@ import (
 	"github.com/vinyl-linux/vin/config"
 )
 
+const flags = "-g -O2 -pipe -Wall"
+
 // adviseCmd represents the advise command
 var adviseCmd = &cobra.Command{
 	Use:   "advise",
@@ -48,11 +50,11 @@ var adviseCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		c := config.Config{}
 
-		c.ConfigureFlags = "--prefix=/ --enable-openssl --disable-multilib"
+		c.ConfigureFlags = "--prefix=/ --enable-openssl --disable-multilib --with-system-zlib"
 		c.MakeOpts = fmt.Sprintf("-j%d", int(math.Max(float64(runtime.NumCPU()-1), 1.0)))
 
-		c.CFlags = "-D_FORTIFY_SOURCE=2 -fasynchronous-unwind-tables -fexceptions -fpie -Wl,-pie -fpic -shared -fstack-clash-protection -fstack-protector-strong -O2 -pipe -Wall -Werror=format-security -Werror=implicit-function-declaration -Wl,-z,defs"
-		c.CXXFlags = c.CFlags
+		c.CFlags = flags
+		c.CXXFlags = flags
 
 		fmt.Fprintln(cmd.OutOrStdout(), "# vin config file")
 		fmt.Fprintln(cmd.OutOrStdout(), "#")

--- a/manifest.go
+++ b/manifest.go
@@ -169,6 +169,7 @@ type Commands struct {
 	Install    *string
 	WorkingDir string
 	Patches    []string
+	Skipenv    bool
 }
 
 // Slice returns each command in an ordered slice
@@ -230,7 +231,7 @@ func (c Commands) Patch(wd string, output chan string) (err error) {
 		patchCmd := fmt.Sprintf("patch -p1 -i %s", p)
 
 		output <- fmt.Sprintf("patch %d/%d", i+1, patches)
-		err = execute(wd, patchCmd, output, config.Config{})
+		err = execute(wd, patchCmd, c.Skipenv, output, config.Config{})
 		if err != nil {
 			return
 		}

--- a/os.go
+++ b/os.go
@@ -209,7 +209,7 @@ func decompressLoop(tr *tar.Reader, dest string) (err error) {
 	}
 }
 
-func execute(dir, command string, output chan string, c config.Config) (err error) {
+func execute(dir, command string, skipEnv bool, output chan string, c config.Config) (err error) {
 	cmdSlice := strings.Fields(command)
 
 	var args []string
@@ -226,8 +226,10 @@ func execute(dir, command string, output chan string, c config.Config) (err erro
 	cmd := exec.CommandContext(context.Background(), cmdSlice[0], args...)
 	cmd.Dir = dir
 
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, fmt.Sprintf("CFLAGS=%s", c.CFlags), fmt.Sprintf("CXXFLAGS=%s", c.CXXFlags))
+	if !skipEnv {
+		cmd.Env = os.Environ()
+		cmd.Env = append(cmd.Env, fmt.Sprintf("CFLAGS=%s", c.CFlags), fmt.Sprintf("CXXFLAGS=%s", c.CXXFlags))
+	}
 
 	outputWriter := ChanWriter(output)
 	cmd.Stdout = outputWriter

--- a/os_test.go
+++ b/os_test.go
@@ -72,7 +72,7 @@ func TestExecute(t *testing.T) {
 				}
 			}()
 
-			err := execute(test.dir, test.command, output, config.Config{})
+			err := execute(test.dir, test.command, false, output, config.Config{})
 			close(output)
 			if err == nil && test.expectError {
 				t.Errorf("expected error")

--- a/server.go
+++ b/server.go
@@ -131,7 +131,7 @@ func (s Server) Install(is *server.InstallSpec, vs server.Vin_InstallServer) (er
 				return
 			}
 
-			err = execute(workDir, cmd, output.C, s.config)
+			err = execute(workDir, cmd, task.Commands.Skipenv, output.C, s.config)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
The default flags, and setting `CFLAGS` causes all kinds of nonsense for things like m4, where getting too clever requires `autoconf`, which requires `texinfo`, which requires `m4`.

I'm starting to think that GNU can go and do one