### PR TITLE
Remove symlink dests before linking

### DIFF
--- a/os.go
+++ b/os.go
@@ -259,6 +259,14 @@ func installServiceDir(src string) (err error) {
 				return err
 			}
 
+			// delete destination first; otherwise os.Symlink
+			// will error.
+			//
+			// Ignore the error; the only pertinent error is
+			// that the destination does not exist (which we don't
+			// care about)- anything else will be caught elsewhere
+			os.Remove(dst)
+
 			return os.Symlink(l, dst)
 		}
 


### PR DESCRIPTION
Go is unable to create a symlink ontop of an already existent file/ symlink so mimic the behaviour of `ln -sf src dst` by removing the dst first