### PR TITLE
Allow the loading of pre-releases when constraint is latest

### DIFF
--- a/manifest_db.go
+++ b/manifest_db.go
@@ -63,12 +63,24 @@ func (d ManifestDB) Satisfies(pkg string, constraint version.Constraints) (s []*
 		return
 	}
 
+	var (
+		latestManifest *Manifest
+	)
+
 	for obj := it.Next(); obj != nil; obj = it.Next() {
 		m := obj.(*Manifest)
+
+		if constraint.String() == latest.String() && (latestManifest == nil || m.Version.GreaterThan(latestManifest.Version)) {
+			latestManifest = m
+		}
 
 		if constraint.Check(m.Version) {
 			s = append(s, m)
 		}
+	}
+
+	if len(s) == 0 && latestManifest != nil {
+		s = []*Manifest{latestManifest}
 	}
 
 	return

--- a/manifest_db_test.go
+++ b/manifest_db_test.go
@@ -19,22 +19,31 @@ func TestManifestDB_Satisfies(t *testing.T) {
 		t.Fatalf("unexpected error: %+v", err)
 	}
 
-	constraint, _ := version.NewConstraint(">= 1.0.0")
-	pkg := "sample-app"
+	gte1, _ := version.NewConstraint(">= 1.0.0")
 
-	s, err := d.Satisfies(pkg, constraint)
-	t.Logf("%#v", s[0])
+	for _, test := range []struct {
+		name       string
+		pkg        string
+		constraint version.Constraints
+		expect     string
+	}{
+		{"simple, versioned package", "sample-app", gte1, "sample-app 1.0.0"},
+		{"simple app, 'latest' version", "sample-app", latest, "sample-app 1.0.0"},
+		{"app with only so-called pre-releases", "complex-versions-app", latest, "complex-versions-app 3.2.1-r1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s, err := d.Satisfies(test.pkg, test.constraint)
+			if err != nil {
+				t.Fatalf("unexpected error: %+v", err)
+			}
 
-	if err != nil {
-		t.Fatalf("unexpected error: %+v", err)
-	}
+			if len(s) != 1 {
+				t.Fatalf("expected 1 satisfying manifest, received %d", len(s))
+			}
 
-	if len(s) != 1 {
-		t.Errorf("expected 1 satisfying manifest, received %d", len(s))
-	}
-
-	expectID := "sample-app 1.0.0"
-	if s[0].ID != expectID {
-		t.Errorf("expected %q, received %q", expectID, s[0].ID)
+			if s[0].ID != test.expect {
+				t.Errorf("expected %q, received %q", test.expect, s[0].ID)
+			}
+		})
 	}
 }

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -156,7 +156,7 @@ func TestManifests(t *testing.T) {
 		t.Fatalf("unexpected error: %#v", err)
 	}
 
-	expect := 16
+	expect := 20
 	received := len(m)
 
 	if expect != received {

--- a/testdata/manifests/valid-manifests/complex-versions-app/3.2.0-r1/manifest.toml
+++ b/testdata/manifests/valid-manifests/complex-versions-app/3.2.0-r1/manifest.toml
@@ -1,0 +1,6 @@
+provides = "complex-versions-app"
+version = "3.2.0-r1"
+
+[profiles]
+[profiles.default]    # All manifests need a default profile
+deps = []

--- a/testdata/manifests/valid-manifests/complex-versions-app/3.2.0-r2/manifest.toml
+++ b/testdata/manifests/valid-manifests/complex-versions-app/3.2.0-r2/manifest.toml
@@ -1,0 +1,6 @@
+provides = "complex-versions-app"
+version = "3.2.0-r2"
+
+[profiles]
+[profiles.default]    # All manifests need a default profile
+deps = []

--- a/testdata/manifests/valid-manifests/complex-versions-app/3.2.0-r3/manifest.toml
+++ b/testdata/manifests/valid-manifests/complex-versions-app/3.2.0-r3/manifest.toml
@@ -1,0 +1,6 @@
+provides = "complex-versions-app"
+version = "3.2.0-r3"
+
+[profiles]
+[profiles.default]    # All manifests need a default profile
+deps = []

--- a/testdata/manifests/valid-manifests/complex-versions-app/3.2.1-r1/manifest.toml
+++ b/testdata/manifests/valid-manifests/complex-versions-app/3.2.1-r1/manifest.toml
@@ -1,0 +1,6 @@
+provides = "complex-versions-app"
+version = "3.2.1-r1"
+
+[profiles]
+[profiles.default]    # All manifests need a default profile
+deps = []


### PR DESCRIPTION
See: https://github.com/vinyl-linux/vin/issues/35

Because of how go-version parses versions with so-called pre-release tags (see: https://github.com/hashicorp/go-version/pull/35) and because not all packages have strict semver versions (especially ones we have taken from alpine), some packages end up being erroneously listed as uninstallable.

This PR essentially tells vin to install the latest version of a package, even when that version is recognised as a pre-release