### PR TITLE
Register finalisers

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,9 +7,13 @@ import (
 	"github.com/vinyl-linux/vin/config"
 )
 
+var (
+	cfg config.Config
+)
+
 type InstallationValues struct {
-	config.Config
 	*Manifest
+	config.Config
 }
 
 // Expand takes a string (containing an ostensible template) and
@@ -28,12 +32,19 @@ func (c InstallationValues) Expand(s string) (cmd string, err error) {
 		return
 	}
 
+	c.Config = cfg
 	err = tmpl.Execute(b, c)
 	if err != nil {
 		return
 	}
 
 	cmd = b.String()
+
+	return
+}
+
+func loadConfig() (err error) {
+	cfg, err = config.Load(configFile)
 
 	return
 }

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,7 @@ package config
 import (
 	"io/ioutil"
 
-	"github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml/v2"
 )
 
 // Config holds all of the configuration that vin needs,

--- a/config_test.go
+++ b/config_test.go
@@ -2,23 +2,22 @@ package main
 
 import (
 	"testing"
-
-	"github.com/vinyl-linux/vin/config"
 )
 
 func TestInstallationValues_Expand(t *testing.T) {
 	configFile = "testdata/test-config.toml"
 
-	c, err := config.Load(configFile)
+	err := loadConfig()
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
 
 	m := &Manifest{
 		ManifestDir: "/tmp/app/1.0.0/",
+		Commands: Commands{
+			installationValues: InstallationValues{Manifest: &Manifest{ManifestDir: "/tmp/app/1.0.0/"}},
+		},
 	}
-
-	ir := InstallationValues{c, m}
 
 	for _, test := range []struct {
 		name        string
@@ -33,7 +32,7 @@ func TestInstallationValues_Expand(t *testing.T) {
 		{"dodgy template", " {{ .HelloWorld }}", "", true},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := ir.Expand(test.in)
+			got, err := m.Commands.installationValues.Expand(test.in)
 
 			if err == nil && test.expectError {
 				t.Error("expected error, received none")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/go-memdb v1.3.2
 	github.com/hashicorp/go-version v1.4.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/pelletier/go-toml v1.9.4
+	github.com/pelletier/go-toml/v2 v2.0.0-beta.6
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/viper v1.7.1
 	github.com/zeebo/blake3 v0.2.2
@@ -31,6 +31,7 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=
 github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pelletier/go-toml/v2 v2.0.0-beta.6 h1:JFNqj2afbbhCqTiyN16D7Tudc/aaDzE2FBDk+VlBQnE=
+github.com/pelletier/go-toml/v2 v2.0.0-beta.6/go.mod h1:ke6xncR3W76Ba8xnVxkrZG0js6Rd2BsQEAYrfgJ6eQA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -251,8 +253,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942 h1:t0lM6y/M5IiUZyvbBTcngso8SZEZICH7is9B6g/obVU=
+github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
-	"github.com/vinyl-linux/vin/config"
 	"github.com/vinyl-linux/vin/server"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -53,7 +52,7 @@ func Setup() *grpc.Server {
 	sugar.Info("starting")
 	sugar.Info("loading config")
 
-	c, err := config.Load(configFile)
+	err := loadConfig()
 	if err != nil {
 		sugar.Panic(err)
 	}
@@ -77,7 +76,7 @@ func Setup() *grpc.Server {
 	sugar.Info("loaded")
 	sugar.Info("starting server")
 
-	s, err := NewServer(c, mdb, sdb)
+	s, err := NewServer(mdb, sdb)
 	if err != nil {
 		sugar.Panic(err)
 	}

--- a/manifest_db.go
+++ b/manifest_db.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	_ "log"
-
 	"fmt"
 	"sort"
 

--- a/os.go
+++ b/os.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 
 	"github.com/h2non/filetype"
-	"github.com/vinyl-linux/vin/config"
 	"github.com/zeebo/blake3"
 )
 
@@ -237,7 +236,7 @@ func decompressLoop(tr *tar.Reader, dest string) (err error) {
 	}
 }
 
-func execute(dir, command string, skipEnv bool, output chan string, c config.Config) (err error) {
+func execute(dir, command string, skipEnv bool, output chan string) (err error) {
 	cmdSlice := strings.Fields(command)
 
 	var args []string
@@ -256,7 +255,7 @@ func execute(dir, command string, skipEnv bool, output chan string, c config.Con
 
 	if !skipEnv {
 		cmd.Env = os.Environ()
-		cmd.Env = append(cmd.Env, fmt.Sprintf("CFLAGS=%s", c.CFlags), fmt.Sprintf("CXXFLAGS=%s", c.CXXFlags))
+		cmd.Env = append(cmd.Env, fmt.Sprintf("CFLAGS=%s", cfg.CFlags), fmt.Sprintf("CXXFLAGS=%s", cfg.CXXFlags))
 	}
 
 	outputWriter := ChanWriter(output)

--- a/os_test.go
+++ b/os_test.go
@@ -6,8 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/vinyl-linux/vin/config"
 )
 
 func TestUntar(t *testing.T) {
@@ -112,7 +110,7 @@ func TestExecute(t *testing.T) {
 				}
 			}()
 
-			err := execute(test.dir, test.command, false, output, config.Config{})
+			err := execute(test.dir, test.command, false, output)
 			close(output)
 			if err == nil && test.expectError {
 				t.Errorf("expected error")

--- a/server_test.go
+++ b/server_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/go-version"
-	"github.com/vinyl-linux/vin/config"
 	"github.com/vinyl-linux/vin/server"
 	"google.golang.org/grpc"
 )
@@ -29,7 +28,7 @@ func TestServer_Install(t *testing.T) {
 	cacheDir = "/tmp"
 	sockAddr = "/tmp/vin-test.sock"
 
-	c, err := config.Load(configFile)
+	err := loadConfig()
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -39,7 +38,7 @@ func TestServer_Install(t *testing.T) {
 		t.Fatalf("unexpected error: %+v", err)
 	}
 
-	s, err := NewServer(c, mdb, StateDB{})
+	s, err := NewServer(mdb, StateDB{})
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -93,7 +92,7 @@ func TestServer_Install_WithService(t *testing.T) {
 	sockAddr = "/tmp/vin-test.sock"
 	svcDir = "testdata/manifests-with-services/svcDir"
 
-	c, err := config.Load(configFile)
+	err := loadConfig()
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -103,7 +102,7 @@ func TestServer_Install_WithService(t *testing.T) {
 		t.Fatalf("unexpected error: %+v", err)
 	}
 
-	s, err := NewServer(c, mdb, StateDB{})
+	s, err := NewServer(mdb, StateDB{})
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -131,7 +130,7 @@ func TestServer_Reload(t *testing.T) {
 	sockAddr = "/tmp/vin-test.sock"
 	stateDB = filepath.Join("/tmp", uuid.Must(uuid.NewV4()).String())
 
-	c, err := config.Load(configFile)
+	err := loadConfig()
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}
@@ -141,7 +140,7 @@ func TestServer_Reload(t *testing.T) {
 		t.Fatalf("unexpected error: %+v", err)
 	}
 
-	s, err := NewServer(c, mdb, StateDB{})
+	s, err := NewServer(mdb, StateDB{})
 	if err != nil {
 		t.Fatalf("unexpected error: %+v", err)
 	}

--- a/state_test.go
+++ b/state_test.go
@@ -22,8 +22,11 @@ func TestStateDB_Manifest(t *testing.T) {
 
 	got, err := s.Meta()
 	got.Version = nil
+	got.Commands.installationValues = InstallationValues{}
+	got.Commands.absoluteWorkingDir = ""
+	got.dir = ""
 
 	if !reflect.DeepEqual(expect, got) {
-		t.Errorf("expected %#v, recveived %#v", expect, got)
+		t.Errorf("expected\n%#v\n\nrecveived\n%#v", expect, got)
 	}
 }

--- a/testdata/manifests-with-services/another-sample-app/1.0.0/manifest.toml
+++ b/testdata/manifests-with-services/another-sample-app/1.0.0/manifest.toml
@@ -8,6 +8,7 @@ service_directory = "99-sample-app"
 configure = "echo 'skipping'"
 compile = "echo 'skipping'"
 install = "echo 'skipping'"
+finaliser = "echo 'skipping'"
 
 [profiles]
 [profiles.default]    # All manifests need a default profile


### PR DESCRIPTION
Finalisers are scripts which are run at the end of an installation run. This means we can do things like run mkinitrd at the end of a run that includes kernels, headers, and so on